### PR TITLE
Add support for EIP service

### DIFF
--- a/src/leap/bitmask_core/_zmq.py
+++ b/src/leap/bitmask_core/_zmq.py
@@ -138,6 +138,14 @@ class _DispatcherREPConnection(ZmqREPConnection):
 
             eip = self._get_service('eip')
 
+            if subcmd == 'start':
+                r = eip.do_start()
+                self.defer_reply(r, msgId)
+
+            if subcmd == 'stop':
+                r = eip.do_stop()
+                self.defer_reply(r, msgId)
+
     def _get_service(self, name):
         return self.core.getServiceNamed(name)
 

--- a/src/leap/bitmask_core/bitmask_cli.py
+++ b/src/leap/bitmask_core/bitmask_cli.py
@@ -74,8 +74,8 @@ GENERAL COMMANDS:
 
     def user(self):
         parser = argparse.ArgumentParser(
-            description=('Handles Bitmask accounts: creation, authentication and '
-                         'modification'),
+            description=('Handles Bitmask accounts: creation, authentication '
+                         'and modification'),
             prog='bitmask_cli user')
         parser.add_argument('--create', action='store_true',
                             help='register a new user, if possible')
@@ -83,7 +83,8 @@ GENERAL COMMANDS:
                             help='logs in against the provider')
         parser.add_argument('--logout', action='store_true',
                             help='ends any active session with the provider')
-        parser.add_argument('username', help='username ID, in the form <user@example.org>')
+        parser.add_argument('username',
+                            help='username ID, in the form <user@example.org>')
         # now that we're inside a subcommand, ignore the first
         # TWO argvs, ie the command (bitmask_cli) and the subcommand (user)
         args = parser.parse_args(sys.argv[2:])
@@ -108,7 +109,8 @@ GENERAL COMMANDS:
         parser.add_argument('--get-smtp-certificate', action='store_true',
                             help='downloads a new smtp certificate')
         parser.add_argument('--check-smtp-certificate', action='store_true',
-                            help='downloads a new smtp certificate (NOT IMPLEMENTED')
+                            help='downloads a new smtp certificate '
+                            '(NOT IMPLEMENTED)')
 
         args = parser.parse_args(sys.argv[2:])
         self.subargs = args
@@ -117,9 +119,11 @@ GENERAL COMMANDS:
         parser = argparse.ArgumentParser(
             description='Encrypted Internet Proxy service',
             prog='bitmask_cli eip')
-        parser.add_argument('--start', help='Start service')
-        parser.add_argument('--stop', help='Stop service')
-        parser.add_argument('--status', help='Display status about service')
+        parser.add_argument('--start', action='store_true',
+                            help='Start service')
+        parser.add_argument('--stop', action='store_true', help='Stop service')
+        parser.add_argument('--status', action='store_true',
+                            help='Display status about service')
         parser.add_argument('--enable', action='store_true')
         parser.add_argument('--disable', action='store_true')
         args = parser.parse_args(sys.argv[2:])
@@ -210,6 +214,13 @@ def send_command(cli):
 
         if subargs.get_smtp_certificate:
             data = ("mail", "get_smtp_certificate")
+
+    elif cmd == 'eip':
+        if subargs.start:
+            data = ("eip", "start")
+
+        if subargs.stop:
+            data = ("eip", "stop")
 
     s = get_zmq_connection()
     try:

--- a/src/leap/bitmask_core/websocket.py
+++ b/src/leap/bitmask_core/websocket.py
@@ -60,7 +60,7 @@ class DispatcherProtocol(WebSocketServerProtocol):
 
         if cmd == "user":
             subcmd = parts[1]
-            #user, password = parts[2], parts[3]
+            # user, password = parts[2], parts[3]
             user = parts[2]
             password = "lalalala"
 
@@ -90,6 +90,19 @@ class DispatcherProtocol(WebSocketServerProtocol):
                 d = m.get_imap_token()
                 d.addBoth(lambda r: self.defer_reply(str(r), binary))
 
+        if cmd == "eip":
+            subcmd = parts[1]
+
+            e = self._get_service('eip')
+
+            if subcmd == 'start':
+                r = e.do_start()
+                self.defer_reply(r, binary)
+
+            if subcmd == 'stop':
+                r = e.do_stop()
+                self.defer_reply(r, binary)
+
     def reply(self, response, binary):
         self.sendMessage(response, binary)
 
@@ -113,17 +126,20 @@ class WebSocketsDispatcherService(service.Service):
 
     def startService(self):
 
-        factory = WebSocketServerFactory(u"ws://127.0.0.1:%d" % self.port, debug=self.debug)
+        factory = WebSocketServerFactory(u"ws://127.0.0.1:%d" % self.port,
+                                         debug=self.debug)
         factory.protocol = DispatcherProtocol
         factory.protocol.core = self._core
 
-        # FIXME: Site.start/stopFactory should start/stop factories wrapped as Resources
+        # FIXME: Site.start/stopFactory should start/stop factories wrapped as
+        # Resources
         factory.startFactory()
 
         resource = WebSocketResource(factory)
 
         # we server static files under "/" ..
-        webdir = os.path.abspath(pkg_resources.resource_filename("leap.bitmask_core", "web"))
+        webdir = os.path.abspath(
+            pkg_resources.resource_filename("leap.bitmask_core", "web"))
         root = File(webdir)
 
         # and our WebSocket server under "/ws"


### PR DESCRIPTION
support start/stop only for eip,
use on the cli and on the websockets server,
do some pep8 related changes,
refactor do_status to be easily extensible for more services.
