### PR TITLE
Send provider to start vpn with it

### DIFF
--- a/src/leap/bitmask_core/_zmq.py
+++ b/src/leap/bitmask_core/_zmq.py
@@ -139,7 +139,8 @@ class _DispatcherREPConnection(ZmqREPConnection):
             eip = self._get_service('eip')
 
             if subcmd == 'start':
-                r = eip.do_start()
+                provider = parts[2]
+                r = eip.do_start(provider)
                 self.defer_reply(r, msgId)
 
             if subcmd == 'stop':


### PR DESCRIPTION
I've removed the provider name hardcoded from the vpn service, we need to send the provider now.
